### PR TITLE
Configure Giscus with repository discussion details

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,4 +68,10 @@ defaults:
     values:
       language: es
 
+giscus:
+  repo: "freddan58/freddan58.github.io"
+  repoId: "R_kgDOO8N3kg"
+  category: "General"
+  categoryId: "DIC_kwDOO8N3ks4Cu2MC"
+
 #google_analytics: GTM-5ZMNPSR4

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,17 +1,20 @@
-{% if site.disqus.shortname -%}
-  <script>
-    var disqus_config = function () {
-      this.page.url = '{{ page.url | absolute_url }}';
-      this.page.identifier = '{{ page.id }}';
-    };
-    (function() {
-      var d = document, s = d.createElement('script');
-      s.src = 'https://{{ site.disqus.shortname }}.disqus.com/embed.js';
-      s.setAttribute('data-timestamp', +new Date());
-      (d.head || d.body).appendChild(s);
-    })();
+{% if site.giscus.repo and site.giscus.repoId and site.giscus.category and site.giscus.categoryId -%}
+  <script src="https://giscus.app/client.js"
+          data-repo="{{ site.giscus.repo }}"
+          data-repo-id="{{ site.giscus.repoId }}"
+          data-category="{{ site.giscus.category }}"
+          data-category-id="{{ site.giscus.categoryId }}"
+          data-mapping="pathname"
+          data-strict="0"
+          data-reactions-enabled="1"
+          data-emit-metadata="1"
+          data-input-position="top"
+          data-theme="preferred_color_scheme"
+          data-lang="en"
+          data-loading="lazy"
+          crossorigin="anonymous"
+          async>
   </script>
-  <noscript>
-    Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a>
-  </noscript>
+  <noscript>Please enable JavaScript to view the comments powered by Giscus.</noscript>
 {% endif -%}
+


### PR DESCRIPTION
## Summary
- Set Giscus repo and discussion category identifiers
- Enable metadata emission, top-level input, and lazy loading in Giscus script

## Testing
- ❌ `bundle exec jekyll build` *(bundler: command not found: jekyll)*
- ⚠️ `bundle install` *(Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68b5b56c66008320b85fe999bba7d4ef